### PR TITLE
出力パスの表示とストリームのクローズ処理

### DIFF
--- a/JVDownloader/Program.cs
+++ b/JVDownloader/Program.cs
@@ -382,6 +382,8 @@ YYYY:開催年, MM:開催月, DD:開催日, JJ:場コード, KK:回次, HH:日�
             }
             progressThread.Join();
 
+            Console.WriteLine(outputPath);
+
             streamWriter.Close();
             jvLink.JVClose();
 


### PR DESCRIPTION
出力パスの表示とストリームのクローズ処理

`outputPath`をコンソールに出力する行を追加し、`streamWriter`を閉じる処理を追加しました。また、`jvLink.JVClose()`の後に`Thread.Sleep(wait);`を配置しました。